### PR TITLE
Add option: max_width

### DIFF
--- a/lib/Number/Util/Range.pm
+++ b/lib/Number/Util/Range.pm
@@ -33,6 +33,10 @@ $SPEC{'convert_number_sequence_to_range'} = {
             schema => 'str*',
             default => '..',
         },
+        max_width => {
+            schema => 'posint*',
+            default => 0,
+        },
     },
     result_naked => 1,
     examples => [
@@ -74,6 +78,14 @@ $SPEC{'convert_number_sequence_to_range'} = {
             },
             result => ["1..4", 9],
         },
+        {
+            summary => 'option: max_width',
+            args => {
+                array => [98, 100..110, 5, 101],
+                max_width => 4,
+            },
+            result => [98, "100..103","104..107","108..110", 2, 3, 4, 5, 101],
+        },
     ],
 };
 sub convert_number_sequence_to_range {
@@ -83,6 +95,7 @@ sub convert_number_sequence_to_range {
     my $threshold = $args{threshold} // 4;
     my $separator = $args{separator} // '..';
     my $ignore_duplicates = $args{ignore_duplicates};
+    my $max_width = $args{max_width} // 0;
 
     my @res;
     my @buf; # to hold possible sequence
@@ -106,6 +119,9 @@ sub convert_number_sequence_to_range {
         }
         if (@buf) {
             if ($el != $buf[-1]+1) { # breaks current sequence
+                $code_empty_buffer->();
+            }
+            if ( $max_width && @buf >= $max_width ) {
                 $code_empty_buffer->();
             }
         }


### PR DESCRIPTION
I'm using ezmlm to retrieve some older mailing messages, and `Number::Util::Range` to build email address for its `get` command.

However, ezmlm won't send back more than a hundred messages, as documented:

    To retrieve a set of messages 123-145 (a maximum of 100 per request),                                                                                                                                              
    send an empty message to:                                                                                                                                                                                          
       <cpan-testers-discuss-get.123_145@perl.org>                                                                                                                                                                     

This patch to `Number::Util::Range` allows me to generate the request email addresses easily.